### PR TITLE
Don’t bind unused parameters

### DIFF
--- a/Traversal/ReducibleOf.swift
+++ b/Traversal/ReducibleOf.swift
@@ -18,7 +18,7 @@ public struct ReducibleOf<T> : ReducibleType {
 	/// Nonrecursive left reduction.
 	public func reduceLeft<Result>(recur: (ReducibleOf, Result, (Result, T) -> Either<Result, Result>) -> Result) -> (ReducibleOf, Result, (Result, T) -> Either<Result, Result>) -> Result {
 		var producer = self.producer()
-		return { collection, initial, combine in
+		return { _, initial, combine in
 			return producer().map { combine(initial, $0).map{ recur(self, $0, combine) }.either(id, id) } ?? initial
 		}
 	}


### PR DESCRIPTION
This changes the backtrace from #1 very slightly to crash in `_swift_release_(swift::HeapObject*)` instead of `direct type metadata for Swift.Int`.
