### PR TITLE
Fix infinite recursion

### DIFF
--- a/Traversal/ReducibleOf.swift
+++ b/Traversal/ReducibleOf.swift
@@ -19,7 +19,7 @@ public struct ReducibleOf<T> : ReducibleType {
 	public func reduceLeft<Result>(recur: (ReducibleOf, Result, (Result, T) -> Either<Result, Result>) -> Result) -> (ReducibleOf, Result, (Result, T) -> Either<Result, Result>) -> Result {
 		var producer = self.producer()
 		return { collection, initial, combine in
-			return producer().map { combine(initial, $0).map{ recur(ReducibleOf { producer }, $0, combine) }.either(id, id) } ?? initial
+			return producer().map { combine(initial, $0).map { recur(ReducibleOf { producer }, $0, combine) }.either(id, id) } ?? initial
 		}
 	}
 


### PR DESCRIPTION
Fixes infinite recursion in the unit tests now that 6.1 GM seed 2 is out and fixes the issues that were crashing us.
