### PR TITLE
Broken codegen for recursive function in Xcode 6.1 GM seed 2

### DIFF
--- a/Traversal/Stream.swift
+++ b/Traversal/Stream.swift
@@ -28,9 +28,7 @@ extension Stream {
 		recur = { reducible, initial, combine in
 			switch initial {
 			case Nil: return Nil
-			case let Cons(x, _):
-				let y = reducible.reduceLeft(recur)(reducible, Nil, combine)
-				return Cons(x, y)
+			case let Cons(x, _): return Cons(x, reducible.reduceLeft(recur)(reducible, Nil, combine))
 			}
 		}
 


### PR DESCRIPTION
The compiler terminates early with a message apparently indicating broken codegen:

```
Stored value type does not match pointer operand type!
  store %SQ.17* %5, %SQ** %45, align 8, !dbg !422
 %SQ*LLVM ERROR: Broken function found, compilation aborted!
```
