### PR TITLE
ReducibleOf conforms to SequenceType.

### DIFF
--- a/Traversal/ReducibleOf.swift
+++ b/Traversal/ReducibleOf.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2014 Rob Rix. All rights reserved.
 
 /// A reducible over a sequence.
-public struct ReducibleOf<T> : ReducibleType {
+public struct ReducibleOf<T> : ReducibleType, SequenceType {
 	// MARK: Lifecycle
 
 	/// Initializes with a sequence.
@@ -21,6 +21,12 @@ public struct ReducibleOf<T> : ReducibleType {
 		return { collection, initial, combine in
 			return producer().map { combine(initial, $0).map { recur(ReducibleOf { producer }, $0, combine) }.either(id, id) } ?? initial
 		}
+	}
+
+
+	// MARK: SequenceType conformance.
+	public func generate() -> GeneratorOf<T> {
+		return GeneratorOf(Stream(self).generate())
 	}
 
 


### PR DESCRIPTION
This is a convenience, allowing `ReducibleOf` to be used in `for`/`in` statements.
