### PR TITLE
ReducibleOf can be initialized with ReducibleType.

### DIFF
--- a/Traversal/ReducibleOf.swift
+++ b/Traversal/ReducibleOf.swift
@@ -12,6 +12,11 @@ public struct ReducibleOf<T> : ReducibleType, SequenceType {
 		})
 	}
 
+	/// Initializes with a reducible.
+	public init<R: ReducibleType where R.Element == T>(_ reducible: R) {
+		self.init(Stream(reducible))
+	}
+
 
 	// MARK: ReducibleType
 


### PR DESCRIPTION
This is a convenience to allow private types implementing `ReducibleType` to be wrapped in `ReducibleOf`, thus avoiding leaking implementation details via return types.
