### PR TITLE
Stream combinators

### DIFF
--- a/Traversal/Stream.swift
+++ b/Traversal/Stream.swift
@@ -89,6 +89,13 @@ public enum Stream<T> {
 		if n <= 0 { return self }
 		return rest.drop(n - 1)
 	}
+
+
+	/// Returns a `Stream` produced by mapping the elements of the receiver with `f`.
+	public func map<U>(f: T -> U) -> Stream<U> {
+		let rest = self.rest
+		return first.map { .cons(f($0), rest.map(f)) } ?? Stream<U>.Nil
+	}
 }
 
 

--- a/TraversalTests/StreamTests.swift
+++ b/TraversalTests/StreamTests.swift
@@ -162,4 +162,8 @@ class StreamTests: XCTestCase {
 		let stream = Stream([1, 2, 3])
 		XCTAssertTrue(stream.drop(-1) == stream)
 	}
+
+	func testMap() {
+		XCTAssertEqual(Array(fibonacci.map { $0 * $0 }.take(3)), [1, 4, 9])
+	}
 }


### PR DESCRIPTION
Adds `take`, `drop`, and `map`. Others to follow in other PRs, probably.

Resolves #29.
