### PR TITLE
Nil literal convertible

### DIFF
--- a/Traversal/Convolve.swift
+++ b/Traversal/Convolve.swift
@@ -9,7 +9,7 @@ public func convolve<R0: ReducibleType, R1: ReducibleType>(r0: R0, r1: R1) -> St
 	case let (.Cons(x, xs), .Cons(y, ys)):
 		return .cons((x.value, y.value), (convolve(xs.value, ys.value)))
 	default:
-		return .Nil
+		return nil
 	}
 }
 
@@ -23,7 +23,7 @@ public func convolve<R0: ReducibleType, R1: ReducibleType, R2: ReducibleType>(r0
 	case let (.Cons(x, xs), .Cons(y, ys), .Cons(z, zs)):
 		return .cons((x.value, y.value, z.value), (convolve(xs.value, ys.value, zs.value)))
 	default:
-		return .Nil
+		return nil
 	}
 }
 

--- a/Traversal/Filter.swift
+++ b/Traversal/Filter.swift
@@ -3,7 +3,7 @@
 /// Returns a reducer filtering out any elements of `reducible` which are not matched by `predicate`.
 public func filter<Base: ReducibleType>(reducible: Base, predicate: Base.Element -> Bool) -> ReducerOf<Base, Stream<Base.Element>> {
 	return flattenMap(reducible) {
-		predicate($0) ? .unit($0) : .Nil
+		predicate($0) ? .unit($0) : nil
 	}
 }
 

--- a/Traversal/Stream.swift
+++ b/Traversal/Stream.swift
@@ -18,10 +18,10 @@ public enum Stream<T>: NilLiteralConvertible {
 		let reducer: Reducible<R, Stream, T>.Enumerator -> Reducible<R, Stream, T>.Enumerator = reducible.reducer()
 		let reduce: Reducible<R, Stream, T>.Enumerator = fix { recur in
 			reducer { reducible, initial, combine in
-				initial.first.map { .cons($0, recur(reducible, Nil, combine)) } ?? Nil
+				initial.first.map { .cons($0, recur(reducible, nil, combine)) } ?? nil
 			}
 		}
-		self = reduce(reducible, Nil) {
+		self = reduce(reducible, nil) {
 			.right(.unit($1))
 		}
 	}
@@ -42,7 +42,7 @@ public enum Stream<T>: NilLiteralConvertible {
 	/// Maps a generator of `T?` into a generator of `Stream`.
 	public static func construct(generate: () -> T?) -> () -> Stream<T> {
 		return fix { recur in
-			{ generate().map { self.cons($0, recur()) } ?? Nil }
+			{ generate().map { self.cons($0, recur()) } ?? nil }
 		}
 	}
 
@@ -58,7 +58,7 @@ public enum Stream<T>: NilLiteralConvertible {
 
 	/// Constructs a unary `Stream` of `x`.
 	public static func unit(x: T) -> Stream {
-		return Cons(Box(x), Memo(.Nil))
+		return Cons(Box(x), Memo(nil))
 	}
 
 	/// Constructs a `Stream` of `reducible`. Unlike the corresponding `init`, this is suitable for function composition.
@@ -74,7 +74,7 @@ public enum Stream<T>: NilLiteralConvertible {
 	}
 
 	public var rest: Stream {
-		return destructure()?.1.value ?? Nil
+		return destructure()?.1.value ?? nil
 	}
 
 
@@ -94,9 +94,9 @@ public enum Stream<T>: NilLiteralConvertible {
 	///
 	/// If `n` <= 0, returns the empty `Stream`.
 	public func take(n: Int) -> Stream {
-		if n <= 0 { return Nil }
+		if n <= 0 { return nil }
 
-		return destructure().map { .cons($0, $1.value.take(n - 1)) } ?? Nil
+		return destructure().map { .cons($0, $1.value.take(n - 1)) } ?? nil
 	}
 
 	/// Returns a `Stream` without the first `n` elements of `stream`.
@@ -113,7 +113,7 @@ public enum Stream<T>: NilLiteralConvertible {
 
 	/// Returns a `Stream` produced by mapping the elements of the receiver with `f`.
 	public func map<U>(f: T -> U) -> Stream<U> {
-		return destructure().map { .cons(f($0), $1.value.map(f)) } ?? .Nil
+		return destructure().map { .cons(f($0), $1.value.map(f)) } ?? nil
 	}
 
 
@@ -132,7 +132,7 @@ public enum Stream<T>: NilLiteralConvertible {
 	///
 	/// This is dual to `foldRight`. Where `foldRight` takes a right-associative combine function which takes the current value and the current accumulator and returns the next accumulator, `unfoldRight` takes the current state and returns the current value and the next state.
 	public static func unfoldRight<State>(state: State, unspool: State -> (T, State)?) -> Stream {
-		return unspool(state).map { value, next in self.cons(value, self.unfoldRight(next, unspool)) } ?? Nil
+		return unspool(state).map { value, next in self.cons(value, self.unfoldRight(next, unspool)) } ?? nil
 	}
 
 	/// Unfolds a new `Stream` starting from the initial state `state` and producing pairs of new states and values with `unspool`.
@@ -148,13 +148,13 @@ public enum Stream<T>: NilLiteralConvertible {
 			{ state, stream in
 				unspool(state).map { next, value in prepend(next, self.cons(value, stream)) } ?? stream
 			}
-		} (state, Nil)
+		} (state, nil)
 	}
 
 
 	/// Produces a `Stream` by mapping the elements of the receiver into reducibles and concatenating their elements.
 	public func flattenMap<R: ReducibleType>(f: T -> R) -> Stream<R.Element> {
-		return foldRight(.Nil, f >>> Stream<R.Element>.with >>> (++))
+		return foldRight(nil, f >>> Stream<R.Element>.with >>> (++))
 	}
 
 

--- a/TraversalTests/ConcatTests.swift
+++ b/TraversalTests/ConcatTests.swift
@@ -47,15 +47,15 @@ class ConcatTests: XCTestCase {
 	}
 
 	func testInfixConcatenationOfNilAndNilIsNil() {
-		XCTAssertEqual([Int]() + (Stream<Int>.Nil ++ Stream<Int>.Nil), [])
+		XCTAssertEqual([Int]() + (nil ++ nil), [])
 	}
 
 	func testInfixConcatenationOfNilAndXIsX() {
-		XCTAssertEqual([Int]() + (Stream.Nil ++ Stream.unit(0)), [0])
+		XCTAssertEqual([Int]() + (nil ++ Stream.unit(0)), [0])
 	}
 
 	func testInfixConcatenationOfXAndNilIsX() {
-		XCTAssertEqual([Int]() + (Stream.unit(0) ++ Stream.Nil), [0])
+		XCTAssertEqual([Int]() + (Stream.unit(0) ++ nil), [0])
 	}
 
 	func testInfixConcatenationOfXAndyIsXY() {

--- a/TraversalTests/FlattenMapTests.swift
+++ b/TraversalTests/FlattenMapTests.swift
@@ -15,7 +15,7 @@ class FlattenMapTests: XCTestCase {
 		let sequence = [1, 2, 3, 4, 5, 6, 7, 8, 9]
 		let reducible = Stream(sequence)
 		let filtered = flattenMap(reducible) {
-			$0 % 2 == 0 ? Stream.Nil : Stream.cons($0, Stream.Nil)
+			$0 % 2 == 0 ? nil : Stream.unit($0)
 		}
 		XCTAssertEqual(reduce(filtered, 0, +), 25)
 	}
@@ -24,7 +24,7 @@ class FlattenMapTests: XCTestCase {
 		let sequence = [1, 2, 3, 4]
 		let reducible = Stream(sequence)
 		let mapped = flattenMap(reducible) {
-			Stream.cons($0 * 2, Stream.Nil)
+			Stream.unit($0 * 2)
 		}
 		XCTAssertEqual(reduce(mapped, 0, +), 20)
 	}

--- a/TraversalTests/StreamTests.swift
+++ b/TraversalTests/StreamTests.swift
@@ -90,11 +90,11 @@ class StreamTests: XCTestCase {
 
 	func testStreamReductionIsLeftReduce() {
 		XCTAssertEqual(Traversal.reduce(Stream(["1", "2", "3"]), "0", +), "0123")
-		XCTAssertEqual(Traversal.reduce(Stream.cons("1", Stream.cons("2", Stream.cons("3", Stream.Nil))), "0", +), "0123")
+		XCTAssertEqual(Traversal.reduce(Stream.cons("1", Stream.cons("2", Stream.unit("3"))), "0", +), "0123")
 	}
 
 	func testConstructsNilFromGeneratorOfConstantNil() {
-		XCTAssertTrue(Stream<Int> { nil } == Stream<Int>.Nil)
+		XCTAssertTrue(Stream<Int> { nil } == nil)
 	}
 
 	func testConstructsConsFromGeneratorOfConstantNonNil() {
@@ -117,9 +117,9 @@ class StreamTests: XCTestCase {
 	}
 
 	func testCons() {
-		let stream = Stream.cons(0, Stream.Nil)
+		let stream = Stream.unit(0)
 		XCTAssertEqual(first(stream) ?? -1, 0)
-		XCTAssert(dropFirst(stream) == Stream.Nil)
+		XCTAssert(dropFirst(stream) == nil)
 	}
 
 	let fibonacci: Stream<Int> = fix { fib in
@@ -133,12 +133,12 @@ class StreamTests: XCTestCase {
 
 	func testTakeOfZeroIsNil() {
 		let stream = fibonacci.take(0)
-		XCTAssertTrue(stream == .Nil)
+		XCTAssertTrue(stream == nil)
 	}
 
 	func testTakeOfNegativeIsNil() {
 		let stream = fibonacci.take(-1)
-		XCTAssertTrue(stream == .Nil)
+		XCTAssertTrue(stream == nil)
 	}
 
 	func testDrop() {
@@ -161,15 +161,15 @@ class StreamTests: XCTestCase {
 	}
 
 	func testConcatenationOfNilAndNilIsNil() {
-		XCTAssertEqual([Int]() + (Stream<Int>.Nil ++ Stream<Int>.Nil), [])
+		XCTAssertEqual([Int]() + (nil ++ nil), [])
 	}
 
 	func testConcatenationOfNilAndXIsX() {
-		XCTAssertEqual([Int]() + (Stream.Nil ++ Stream.unit(0)), [0])
+		XCTAssertEqual([Int]() + (nil ++ Stream.unit(0)), [0])
 	}
 
 	func testConcatenationOfXAndNilIsX() {
-		XCTAssertEqual([Int]() + (Stream.unit(0) ++ Stream.Nil), [0])
+		XCTAssertEqual([Int]() + (Stream.unit(0) ++ nil), [0])
 	}
 
 	func testConcatenationOfXAndyIsXY() {


### PR DESCRIPTION
Stream conforms to `NilLiteralConvertible`, and we use `nil` wherever possible.

In addition to reducing the cognitive load of the type, this has much better behaviour w.r.t. type inferencing in a couple of cases:
- when returning `Stream<U>` from a method on `Stream<T>`
- when the value would otherwise have to be explicitly specified as `Stream<Int>.Nil` instead of simply `.Nil` or `Nil`

Fixes #38.
