### PR TITLE
Collection type

### DIFF
--- a/Traversal.xcodeproj/project.pbxproj
+++ b/Traversal.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		D4D9A4D31A2ECA2D000D9C23 /* Memo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4D9A4D21A2ECA2D000D9C23 /* Memo.framework */; };
 		D4D9A4D41A2ECA59000D9C23 /* Memo.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4D9A4D21A2ECA2D000D9C23 /* Memo.framework */; };
 		D4E2C50F19E6385700A4C55A /* StreamTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E2C50E19E6385700A4C55A /* StreamTests.swift */; };
+		D4EC19041AACFD7C003733D4 /* CollectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4EC19031AACFD7C003733D4 /* CollectionTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -81,6 +82,7 @@
 		D4D3E32B1A1EBC28001A9ED4 /* SequenceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SequenceTests.swift; sourceTree = "<group>"; };
 		D4D9A4D21A2ECA2D000D9C23 /* Memo.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Memo.framework; path = "../../../../Library/Developer/Xcode/DerivedData/Traversal-dlyjhvwonwhswzdbfpsuoweyfpdp/Build/Products/Debug/Memo.framework"; sourceTree = "<group>"; };
 		D4E2C50E19E6385700A4C55A /* StreamTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StreamTests.swift; sourceTree = "<group>"; };
+		D4EC19031AACFD7C003733D4 /* CollectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CollectionTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -172,6 +174,7 @@
 			isa = PBXGroup;
 			children = (
 				D4E2C50E19E6385700A4C55A /* StreamTests.swift */,
+				D4EC19031AACFD7C003733D4 /* CollectionTests.swift */,
 				D430A1761A06341E004D8A26 /* MapTests.swift */,
 				D430A1921A0D038F004D8A26 /* FilterTests.swift */,
 				D430A1961A0D0B20004D8A26 /* FlattenMapTests.swift */,
@@ -324,6 +327,7 @@
 				D4C9A11F1A34FCC2009C6CD3 /* AppendingTests.swift in Sources */,
 				D4E2C50F19E6385700A4C55A /* StreamTests.swift in Sources */,
 				D45B60E91A0D46CB0009D607 /* JoinTests.swift in Sources */,
+				D4EC19041AACFD7C003733D4 /* CollectionTests.swift in Sources */,
 				D430A1771A06341E004D8A26 /* MapTests.swift in Sources */,
 				D408804C1A22677200BB9997 /* ReducerOfTests.swift in Sources */,
 				D430A1A21A0D37D8004D8A26 /* ZipTests.swift in Sources */,

--- a/Traversal/Appending.swift
+++ b/Traversal/Appending.swift
@@ -8,6 +8,11 @@ public func += <E: ExtensibleCollectionType, R: ReducibleType where R.Element ==
 }
 
 /// Returns a copy of `left` with the elements of `right` appended onto it.
+public func + <E: ExtensibleCollectionType, R: ReducibleType where R: CollectionType, R.Element == E.Generator.Element> (left: E, right: R) -> E {
+	return reduce(right, left) { $0 + [$1] }
+}
+
+/// Returns a copy of `left` with the elements of `right` appended onto it.
 public func + <E: ExtensibleCollectionType, R: ReducibleType where R.Element == E.Generator.Element> (left: E, right: R) -> E {
 	return reduce(right, left) { $0 + [$1] }
 }

--- a/Traversal/Stream.swift
+++ b/Traversal/Stream.swift
@@ -232,6 +232,22 @@ public enum Stream<T>: ArrayLiteralConvertible, NilLiteralConvertible, Printable
 	case Nil
 }
 
+public struct StreamIndex<T>: ForwardIndexType {
+	let stream: Memo<Stream<T>>
+	let index: Int
+
+
+	// MARK: ForwardIndexType
+
+	public func successor() -> StreamIndex {
+		return StreamIndex(stream: stream.map { $0.rest }, index: index + 1)
+	}
+}
+
+public func == <T> (left: StreamIndex<T>, right: StreamIndex<T>) -> Bool {
+	return left.index == right.index
+}
+
 
 // MARK: Concatenation
 

--- a/Traversal/Stream.swift
+++ b/Traversal/Stream.swift
@@ -188,15 +188,15 @@ public enum Stream<T>: ArrayLiteralConvertible, CollectionType, NilLiteralConver
 	// MARK: CollectionType
 
 	public var startIndex: StreamIndex<T> {
-		return StreamIndex(stream: Memo(evaluated: self), index: 0)
+		return StreamIndex(stream: self, index: 0)
 	}
 
 	public var endIndex: StreamIndex<T> {
-		return StreamIndex(stream: Memo(evaluated: nil), index: -1)
+		return StreamIndex(stream: nil, index: -1)
 	}
 
 	public subscript (index: StreamIndex<T>) -> T {
-		return index.stream.value.first!
+		return index.stream.first!
 	}
 
 
@@ -260,14 +260,14 @@ public enum Stream<T>: ArrayLiteralConvertible, CollectionType, NilLiteralConver
 }
 
 public struct StreamIndex<T>: ForwardIndexType {
-	let stream: Memo<Stream<T>>
+	let stream: Stream<T>
 	let index: Int
 
 
 	// MARK: ForwardIndexType
 
 	public func successor() -> StreamIndex {
-		return StreamIndex(stream: stream.map { $0.rest }, index: index + 1)
+		return StreamIndex(stream: stream.rest, index: index + 1)
 	}
 }
 

--- a/Traversal/Stream.swift
+++ b/Traversal/Stream.swift
@@ -267,7 +267,7 @@ public struct StreamIndex<T>: ForwardIndexType {
 	// MARK: ForwardIndexType
 
 	public func successor() -> StreamIndex {
-		return StreamIndex(stream: stream.rest, index: index + 1)
+		return StreamIndex(stream: stream.rest, index: stream.rest.isEmpty ? -1 : index + 1)
 	}
 }
 

--- a/Traversal/Stream.swift
+++ b/Traversal/Stream.swift
@@ -71,6 +71,11 @@ public enum Stream<T>: ArrayLiteralConvertible, CollectionType, NilLiteralConver
 		return uncons()?.1.value ?? nil
 	}
 
+	/// Is this the empty stream?
+	public var isEmpty: Bool {
+		return uncons() == nil
+	}
+
 
 	/// Unpacks the receiver into an optional tuple of its first element and the memoized remainder.
 	///

--- a/Traversal/Stream.swift
+++ b/Traversal/Stream.swift
@@ -1,7 +1,7 @@
 //  Copyright (c) 2014 Rob Rix. All rights reserved.
 
 /// An iterable stream.
-public enum Stream<T>: ArrayLiteralConvertible, NilLiteralConvertible, Printable, ReducibleType {
+public enum Stream<T>: ArrayLiteralConvertible, CollectionType, NilLiteralConvertible, Printable, ReducibleType {
 
 	// MARK: Lifecycle
 
@@ -180,6 +180,21 @@ public enum Stream<T>: ArrayLiteralConvertible, NilLiteralConvertible, Printable
 	}
 
 
+	// MARK: CollectionType
+
+	public var startIndex: StreamIndex<T> {
+		return StreamIndex(stream: Memo(evaluated: self), index: 0)
+	}
+
+	public var endIndex: StreamIndex<T> {
+		return StreamIndex(stream: Memo(evaluated: nil), index: -1)
+	}
+
+	public subscript (index: StreamIndex<T>) -> T {
+		return index.stream.value.first!
+	}
+
+
 	// MARK: NilLiteralConvertible
 
 	/// Constructs a `Nil` `Stream`.
@@ -216,6 +231,13 @@ public enum Stream<T>: ArrayLiteralConvertible, NilLiteralConvertible, Printable
 				} ?? initial
 			}
 		}
+	}
+
+
+	// MARK: SequenceType
+
+	public func generate() -> IndexingGenerator<Stream> {
+		return IndexingGenerator(self)
 	}
 
 

--- a/Traversal/Stream.swift
+++ b/Traversal/Stream.swift
@@ -188,7 +188,7 @@ public enum Stream<T>: ArrayLiteralConvertible, CollectionType, NilLiteralConver
 	// MARK: CollectionType
 
 	public var startIndex: StreamIndex<T> {
-		return StreamIndex(stream: self, index: 0)
+		return StreamIndex(stream: self, index: isEmpty ? -1 : 0)
 	}
 
 	public var endIndex: StreamIndex<T> {

--- a/TraversalTests/CollectionTests.swift
+++ b/TraversalTests/CollectionTests.swift
@@ -5,6 +5,11 @@ final class CollectionTests: XCTestCase {
 		let stream: Stream<Int> = [ 1, 2, 3 ]
 		XCTAssertEqual(count(stream), 3)
 	}
+
+	func testCanConstructRangesOverFiniteStreams() {
+		let stream: Stream<Int> = [ 1, 2, 3 ]
+		XCTAssertEqual(count(indices(stream)), 3)
+	}
 }
 
 

--- a/TraversalTests/CollectionTests.swift
+++ b/TraversalTests/CollectionTests.swift
@@ -1,24 +1,23 @@
 //  Copyright (c) 2015 Rob Rix. All rights reserved.
 
 final class CollectionTests: XCTestCase {
+	let empty: Stream<Int> = nil
+	let finite: Stream<Int> = [ 1, 2, 3 ]
+
 	func testCountingFiniteStreams() {
-		let stream: Stream<Int> = [ 1, 2, 3 ]
-		XCTAssertEqual(count(stream), 3)
+		XCTAssertEqual(count(finite), 3)
 	}
 
 	func testCanConstructRangesOverFiniteStreams() {
-		let stream: Stream<Int> = [ 1, 2, 3 ]
-		XCTAssertEqual(count(indices(stream)), 3)
+		XCTAssertEqual(count(indices(finite)), 3)
 	}
 
 	func testFindOverFiniteStreams() {
-		let stream: Stream<Int> = [ 1, 2, 3 ]
-		XCTAssertTrue(find(stream, 2) != nil)
+		XCTAssertTrue(find(finite, 2) != nil)
 	}
 
 	func testIsEmptyOverEmptyStreams() {
-		let stream: Stream<Int> = nil
-		XCTAssertTrue(isEmpty(stream))
+		XCTAssertTrue(isEmpty(empty))
 	}
 }
 

--- a/TraversalTests/CollectionTests.swift
+++ b/TraversalTests/CollectionTests.swift
@@ -1,0 +1,14 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+final class CollectionTests: XCTestCase {
+	func testCountingFiniteStreams() {
+		let stream: Stream<Int> = [ 1, 2, 3 ]
+		XCTAssertEqual(count(stream), 3)
+	}
+}
+
+
+// MARK: - Imports
+
+import Traversal
+import XCTest

--- a/TraversalTests/CollectionTests.swift
+++ b/TraversalTests/CollectionTests.swift
@@ -15,6 +15,11 @@ final class CollectionTests: XCTestCase {
 		let stream: Stream<Int> = [ 1, 2, 3 ]
 		XCTAssertTrue(find(stream, 2) != nil)
 	}
+
+	func testIsEmptyOverEmptyStreams() {
+		let stream: Stream<Int> = nil
+		XCTAssertTrue(isEmpty(stream))
+	}
 }
 
 

--- a/TraversalTests/CollectionTests.swift
+++ b/TraversalTests/CollectionTests.swift
@@ -8,6 +8,10 @@ final class CollectionTests: XCTestCase {
 		XCTAssertEqual(count(finite), 3)
 	}
 
+	func testCountingEmptyStreams() {
+		XCTAssertEqual(count(empty), 0)
+	}
+
 	func testCanConstructRangesOverFiniteStreams() {
 		XCTAssertEqual(count(indices(finite)), 3)
 	}

--- a/TraversalTests/CollectionTests.swift
+++ b/TraversalTests/CollectionTests.swift
@@ -10,6 +10,11 @@ final class CollectionTests: XCTestCase {
 		let stream: Stream<Int> = [ 1, 2, 3 ]
 		XCTAssertEqual(count(indices(stream)), 3)
 	}
+
+	func testFindOverFiniteStreams() {
+		let stream: Stream<Int> = [ 1, 2, 3 ]
+		XCTAssertTrue(find(stream, 2) != nil)
+	}
 }
 
 

--- a/TraversalTests/CollectionTests.swift
+++ b/TraversalTests/CollectionTests.swift
@@ -3,6 +3,7 @@
 final class CollectionTests: XCTestCase {
 	let empty: Stream<Int> = nil
 	let finite: Stream<Int> = [ 1, 2, 3 ]
+	let infinite: Stream<Int> = Stream { 0 }
 
 	func testCountingFiniteStreams() {
 		XCTAssertEqual(count(finite), 3)
@@ -12,8 +13,13 @@ final class CollectionTests: XCTestCase {
 		XCTAssertEqual(count(empty), 0)
 	}
 
-	func testCanConstructRangesOverFiniteStreams() {
+	func testRangesOverFiniteStreams() {
 		XCTAssertEqual(count(indices(finite)), 3)
+	}
+
+	func testRangesOverInfiniteStreams() {
+		let i = indices(infinite)
+		XCTAssertEqual(i.endIndex, i.endIndex.successor())
 	}
 
 	func testFindOverFiniteStreams() {

--- a/TraversalTests/StreamTests.swift
+++ b/TraversalTests/StreamTests.swift
@@ -104,7 +104,8 @@ class StreamTests: XCTestCase {
 
 	func testConstructsConsFromGeneratorOfConstantNonNil() {
 		let x: Int? = 1
-		XCTAssertEqual(Stream { x }.first ?? -1, 1)
+		let stream = Stream { x }
+		XCTAssertEqual(stream.first ?? -1, 1)
 	}
 
 	func testConstructsFiniteStreamFromGeneratorOfFiniteSequence() {

--- a/TraversalTests/StreamTests.swift
+++ b/TraversalTests/StreamTests.swift
@@ -15,7 +15,7 @@ struct ReducibleOfThree<T>: ReducibleType {
 		var generator3 = GeneratorOfOne(elements.2)
 		return { recur in
 			{ reducible, initial, combine in
-				(generator1.next() ?? generator2.next() ?? generator3.next()).map { combine(initial, $0).either(id, { recur(reducible, $0, combine) }) } ?? initial
+				(generator1.next() ?? generator2.next() ?? generator3.next()).map { combine(initial, $0).either(ifLeft: id, ifRight: { recur(reducible, $0, combine) }) } ?? initial
 			}
 		}
 	}

--- a/TraversalTests/ZipTests.swift
+++ b/TraversalTests/ZipTests.swift
@@ -7,7 +7,7 @@ import XCTest
 class ZipTests: XCTestCase {
 	func testZipOfTwoParameters() {
 		let r = Stream([1, 2, 3])
-		let zipped = zip(r, r)
+		let zipped = Traversal.zip(r, r)
 		let mapped = Traversal.map(zipped, +)
 		XCTAssertEqual(reduce(mapped, 0, +), 12)
 	}


### PR DESCRIPTION
`Stream` conforms to `CollectionType`.

My initial draft of this had `Stream` return itself as its own index. This would have been exquisitely simple, except that `ForwardIndexType` requires conformance to `Equatable`; therefore, instead of simply using `Stream.Nil` as the `endIndex`, we use a negative index.